### PR TITLE
bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yoshi-cli"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Christian Cleberg", email="hello@cleberg.net" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prettytable~=2.2.0
+prettytable
 cryptography


### PR DESCRIPTION
bumping version to remove `prettytable` version restriction and test out the new deployment restrictions